### PR TITLE
Change all package namespaces to OmegaSpot rather than Spot

### DIFF
--- a/Spot.Backend/Spot.Backend.csproj
+++ b/Spot.Backend/Spot.Backend.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net5.0</TargetFramework>
     <UserSecretsId>c94cc451-41b3-48de-a9ba-aa8499dbc6f9</UserSecretsId>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+    <RootNamespace>OmegaSpot.Backend</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Spot.Common/Spot.Common.csproj
+++ b/Spot.Common/Spot.Common.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
+    <RootNamespace>OmegaSpot.Common</RootNamespace>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Spot.Data/Spot.Data.csproj
+++ b/Spot.Data/Spot.Data.csproj
@@ -5,6 +5,7 @@
     <ApplicationIcon />
     <OutputType>Exe</OutputType>
     <StartupObject>OmegaSpot.Data.Program</StartupObject>
+    <RootNamespace>OmegaSpot.Data</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Spot.Frontend/Spot.Frontend.csproj
+++ b/Spot.Frontend/Spot.Frontend.csproj
@@ -7,6 +7,7 @@
     <IsPackable>false</IsPackable>
     <SpaRoot>ClientApp\</SpaRoot>
     <DefaultItemExcludes>$(DefaultItemExcludes);$(SpaRoot)node_modules\**</DefaultItemExcludes>
+    <RootNamespace>OmegaSpot.Frontend</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Since we have an object called Spot, having a namespace also named spot causes problemas. This will fix the issues of generated code snippets by changing the default namespace to Omegaspot. All classes already use OmegaSpot, but this will allow new classes to automatically have the OmegaSpot namespace (not Spot)