### PR TITLE
Split Checking a reservation into its own route

### DIFF
--- a/Spot.Backend/Spot.Backend.xml
+++ b/Spot.Backend/Spot.Backend.xml
@@ -71,6 +71,11 @@
             <summary>Creates a Reservation Controller</summary>
             <param name="context"></param>
         </member>
+        <member name="M:OmegaSpot.Backend.Controllers.ReservationsController.Check(OmegaSpot.Backend.Requests.CreateReservationRequest)">
+            <summary>Checks a Create Reservation Request</summary>
+            <param name="Request">Request to check</param>
+            <returns></returns>
+        </member>
         <member name="M:OmegaSpot.Backend.Controllers.ReservationsController.CreateReservation(OmegaSpot.Backend.Requests.CreateReservationRequest)">
             <summary>Creates a reservation with given details from the create reservation request</summary>
             <param name="Request">Request to create a reservation with all relevant details</param>


### PR DESCRIPTION
This PR adds POST route `/Reservation/Check` which allows the frontend to check if a `CreateReservationRequest` will conflict (without actually creating the reservation)

This should be tested, as the create reservation call essentially calls the check one and only decides whether or not to continue based on if it returned OK or not. This should be enough, but sabes just in case maybe throw a reservation that conflicts and see what it does.